### PR TITLE
fix: completion not showing after a quote char

### DIFF
--- a/lua/cmp_emoji/init.lua
+++ b/lua/cmp_emoji/init.lua
@@ -12,7 +12,7 @@ source.get_trigger_characters = function()
 end
 
 source.get_keyword_pattern = function()
-  return [=[\%(\s\|^\)\zs:[[:alnum:]_\-\+]*:\?]=]
+  return [=[\%([[:space:]"'`]\|^\)\zs:[[:alnum:]_\-\+]*:\?]=]
 end
 
 source.complete = function(self, params, callback)


### PR DESCRIPTION
no fancy treesitter needed, just a simple modification of the keyword_pattern.

fixes #2 