### PR TITLE
fix: insert false to give word instead of emoji

### DIFF
--- a/lua/cmp_emoji/init.lua
+++ b/lua/cmp_emoji/init.lua
@@ -31,7 +31,11 @@ source.complete = function(self, params, callback)
     callback(self.insert_items)
   else
     if not self.commit_items then
-      self.commit_items = require('cmp_emoji.items')()
+      self.commit_items =vim.tbl_map(function(item)
+        -- appending a space to prevent cmp from triggering for the closing ":"
+        item.insertText = item.word.." "
+        return item
+      end, require('cmp_emoji.items')())
     end
     callback(self.commit_items)
   end


### PR DESCRIPTION
Fixes #7.

Not sure if it's the right way to go about this to achieve this functionality in terms of optimality but for me it achieves the desired functionality with the following minimal config,

```lua
cmp.setup({
    ... -- other generic config options
    sources = {
        { name = "nvim_lsp" },
        { name = "nvim_lua" },
        { name = "luasnip" },
        { name = "buffer" },
        { name = "path" },
        { name = "calc" },
        { name = "emoji", option = { insert = false } },
        { name = "git" },
    },
    ... -- other generic config options
})
```