### PR TITLE
feat: allow emoji suggestions at beginning of string

### DIFF
--- a/lua/cmp_emoji/init.lua
+++ b/lua/cmp_emoji/init.lua
@@ -12,7 +12,7 @@ source.get_trigger_characters = function()
 end
 
 source.get_keyword_pattern = function()
-  return [=[\%(\s\|^\)\zs:[[:alnum:]_\-\+]*:\?]=]
+  return [=[\%([[:space:]"'`]\|^\)\zs:[[:alnum:]_\-\+]*:\?]=]
 end
 
 source.complete = function(self, params, callback)


### PR DESCRIPTION
Taken from #9 which @chrisgrieser created a while ago. Allows for the emoji autocomplete at the beginning of an string.

E.g. typing `:` after `'` or `"` will now show emoji. Previously we required any character after quotations for the emoji to show.

@chrisgrieser please let me know if this ok with you.

@hrsh7th If needed, we can put this behind `opts` flag. Let me know what you think.